### PR TITLE
More Casting: Create a global API

### DIFF
--- a/more-casting/data-final-fixes.lua
+++ b/more-casting/data-final-fixes.lua
@@ -7,42 +7,6 @@ local foundryTechnology = data.raw.technology["foundry"]
 local defaultIconSizeDefine = defines.default_icon_size
 local hideRecipes = settings.startup["more-casting-hide-recipes"].value
 local originalTech = settings.startup["more-casting-original-tech"].value
-local banList = {
-    ["pipe"] = true,
-    ["pipe-to-ground"] = true,
-    ["iron-plate"] = true,
-    ["copper-plate"] = true,
-    ["steel-plate"] = true,
-    ["iron-gear-wheel"] = true,
-    ["iron-stick"] = true,
-    ["low-density-structure"] = true,
-    ["concrete"] = true,
-    ["copper-cable"] = true
-}
-local castingIngredients = {
-    moltenIron = {
-        ["iron-plate"] = 10,      --10, 5
-        ["steel-plate"] = 30,     --30, 20
-        ["iron-gear-wheel"] = 30, --10, 5
-        ["iron-stick"] = 5,       --5, 2.5
-        ["pipe"] = 10             --10, 5
-    },
-    moltenCopper = {
-        ["copper-plate"] = 10, --10, 5
-        ["copper-cable"] = 2.5 --2.5, 1.25
-    }
-}
-local itemRaws = {
-    "item",
-    "item-with-entity-data",
-    "rail-planner",
-    "repair-tool",
-    "ammo",
-    "space-platform-starter-pack",
-    "capsule",
-    "armor",
-    "tool"
-}
 
 local function get_prototype(base_type, name)
     for type_name in pairs(defines.prototypes[base_type]) do
@@ -170,8 +134,8 @@ local function ingredientsMagic(ingredients)
     if ingredients and #ingredients > 0 then
         for index, ingredient in pairs(ingredients) do
             if ingredient.type == "item" then
-                local moltenIronAmountC = castingIngredients.moltenIron[ingredient.name]
-                local moltenCopperAmountC = castingIngredients.moltenCopper[ingredient.name]
+                local moltenIronAmountC = MoreCasting.castingIngredients.moltenIron[ingredient.name]
+                local moltenCopperAmountC = MoreCasting.castingIngredients.moltenCopper[ingredient.name]
 
                 if moltenIronAmountC then
                     moltenIronIngredients = moltenIronIngredients + 1
@@ -213,7 +177,7 @@ local function ingredientsMagic(ingredients)
 end
 
 local function createRecipe(item)
-    if not banList[item.name] then
+    if not MoreCasting.banList[item.name] then
         local recipe = recipes[item.name]
 
         if recipe then
@@ -272,7 +236,7 @@ for _, subGroup in pairs(table.deepcopy(data.raw["item-subgroup"])) do
     })
 end
 
-for _, itemRaw in pairs(itemRaws) do
+for _, itemRaw in pairs(MoreCasting.itemRaws) do
     for _, item in pairs(data.raw[itemRaw]) do
         createRecipe(item)
     end

--- a/more-casting/data.lua
+++ b/more-casting/data.lua
@@ -1,0 +1,67 @@
+local meld = require("__core__/lualib/meld")
+
+--- @alias MoreCasting.CastingFluid "moltenCopper" | "moltenIron"
+--- @alias MoreCasting.CastableIngredientsTable table<data.ItemID, uint>
+
+--- @type table<data.ItemID, boolean>
+local banList = {
+    ["pipe"] = true,
+    ["pipe-to-ground"] = true,
+    ["iron-plate"] = true,
+    ["copper-plate"] = true,
+    ["steel-plate"] = true,
+    ["iron-gear-wheel"] = true,
+    ["iron-stick"] = true,
+    ["low-density-structure"] = true,
+    ["concrete"] = true,
+    ["copper-cable"] = true
+}
+
+--- @type table<string, MoreCasting.CastableIngredientsTable>
+local castingIngredients = {
+    moltenIron = {
+        ["iron-plate"] = 10,      --10, 5
+        ["steel-plate"] = 30,     --30, 20
+        ["iron-gear-wheel"] = 30, --10, 5
+        ["iron-stick"] = 5,       --5, 2.5
+        ["pipe"] = 10             --10, 5
+    },
+    moltenCopper = {
+        ["copper-plate"] = 10, --10, 5
+        ["copper-cable"] = 2.5 --2.5, 1.25
+    }
+}
+
+--- @type string[]
+local itemRaws = {
+    "item",
+    "item-with-entity-data",
+    "rail-planner",
+    "repair-tool",
+    "ammo",
+    "space-platform-starter-pack",
+    "capsule",
+    "armor",
+    "tool"
+}
+
+MoreCasting = MoreCasting or {
+    banList = banList,
+    castingIngredients = castingIngredients,
+    itemRaws = itemRaws
+}
+
+--- Mark all provided items as banned
+--- @param bannedItems data.ItemID[]
+function MoreCasting.ban(bannedItems)
+    for _, item in pairs(bannedItems) do
+        banList[item] = true
+    end
+end
+
+--- Allow provided items to be replaced with a casting fluid in recipes
+--- @param castingFluid MoreCasting.CastingFluid
+--- @param ingredients MoreCasting.CastableIngredientsTable
+function MoreCasting.add_castable_ingredients(castingFluid, ingredients)
+    meld(castingIngredients[castingFluid] or {}, ingredients)
+end

--- a/more-casting/data.lua
+++ b/more-casting/data.lua
@@ -63,5 +63,5 @@ end
 --- @param castingFluid MoreCasting.CastingFluid
 --- @param ingredients MoreCasting.CastableIngredientsTable
 function MoreCasting.add_castable_ingredients(castingFluid, ingredients)
-    meld(castingIngredients[castingFluid] or {}, ingredients)
+    castingIngredients[castingFluid] = meld(castingIngredients[castingFluid] or {}, ingredients)
 end


### PR DESCRIPTION
This PR adds a global API for manipulating banned items, casting substitutions, and the prototype types More Casting will attempt to create recipes for.

Using some Krastorio 2 items as an example;
```lua
MoreCasting.ban({
    -- Ban Krastorio items with their own casting recipes
    "kr-iron-beam",
    "kr-steel-beam",
    "kr-steel-gear-wheel",
    "kr-steel-pipe",
    "kr-steel-pipe-to-ground",
    -- Krastorio adds kr-iron-beam to the recipe, and only plain concrete is covered by MC's default bans
    "refined-concrete"
})

-- Allow these items to be substituted with molten iron
MoreCasting.add_castable_ingredients("moltenIron", {
    ["kr-iron-beam"] = 20,
    ["kr-steel-beam"] = 40,
    ["kr-steel-gear-wheel"] = 20,
    ["kr-steel-pipe"] = 20,
    ["kr-steel-pipe-to-ground"] = 300,
})
```