### PR TITLE
Bugfix - train in train group looses schedule after coupling

### DIFF
--- a/Automatic_Coupling_System/scripts/events.lua
+++ b/Automatic_Coupling_System/scripts/events.lua
@@ -246,10 +246,11 @@ local function doTrainCoupleLogic(train)
 
                             if trainGroup and #trainGroup > 0 then
                                 targetCarriageTrainSchedule.group = trainGroup
-                            else
-                                if scheduleRecords and #scheduleRecords > 0 then targetCarriageTrainSchedule.set_records(scheduleRecords) end
                             end
-
+                            if scheduleRecords and #scheduleRecords > 0 then 
+                                targetCarriageTrainSchedule.set_records(scheduleRecords) 
+                            end
+                            
                             if scheduleCurrent then targetCarriageTrainSchedule.go_to_station(scheduleCurrent) end
 
                             targetCarriageTrainSchedule.set_stopped(false)


### PR DESCRIPTION
Currently when a train with a train group is coupled, it looses its entire schedule. 
Trains without a train group were not affected and worked properly. 

This PR aims to fix that. 
